### PR TITLE
Change Bundel layer attributes to uper case letters

### DIFF
--- a/src/main/js/apps/sample/app.json
+++ b/src/main/js/apps/sample/app.json
@@ -31,15 +31,15 @@
                 "storeId": "flurstuecke_store",
                 "fields": [
                     {
-                        "name": "namgmk",
+                        "name": "NAMGMK",
                         "label": "Gemarkung"
                     },
                     {
-                        "name": "fln",
+                        "name": "FLN",
                         "label": "Flur"
                     },
                     {
-                        "name": "zae",
+                        "name": "ZAE",
                         "label": "Flurstück"
                     }
                 ],

--- a/src/main/js/bundles/dn_hierarchicalsearch/ZoomToResultAction.js
+++ b/src/main/js/bundles/dn_hierarchicalsearch/ZoomToResultAction.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 con terra GmbH (info@conterra.de)
+ * Copyright (C) 2022 con terra GmbH (info@conterra.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
The attributes of the layer changed to capitalized letters. So in the sample app the bundle does not work anymore, since it can not finde the attributes. So here I adjusted the attributes in the app.json to.